### PR TITLE
82 create label for categories on cards

### DIFF
--- a/src/common/CategoryLabel/index.tsx
+++ b/src/common/CategoryLabel/index.tsx
@@ -1,0 +1,9 @@
+import { Label, LabelContainer } from './style'
+
+export default function CategoryLabel({ label }: { label: string }) {
+  return (
+    <LabelContainer>
+      <Label>{label}</Label>
+    </LabelContainer>
+  )
+}

--- a/src/common/CategoryLabel/style.ts
+++ b/src/common/CategoryLabel/style.ts
@@ -1,0 +1,18 @@
+'use client'
+import styled from '@emotion/styled'
+import { $whiteColor, $whiteColorSemi } from '../../styles/_variables'
+
+export const LabelContainer = styled.span`
+  display: inline-block;
+  background-color: ${$whiteColorSemi};
+  padding: 0.25rem 1rem;
+`
+
+export const Label = styled.p`
+  color: ${$whiteColor};
+  font-size: 1rem;
+  text-transform: uppercase;
+  line-height: 1rem;
+  font-weight: 700;
+  margin: 0;
+`

--- a/src/common/index.tsx
+++ b/src/common/index.tsx
@@ -1,2 +1,3 @@
 export { ButtonGradientOutlined, ButtonGradientFilled, ButtonWhite } from './Button'
 export { default as SectionTitle } from './SectionTitle'
+export { default as CategoryLabel } from './CategoryLabel'


### PR DESCRIPTION
This is what it looks like:

![label-in-action](https://github.com/iPlayed-games/frontend/assets/109157075/b496a3c4-bde2-4a24-b906-00dca90ab0f1)

Demo has been removed from the code. currently label is not imported anywhere. 
*the background color is see-through so if used on a different background it may look differently. 
Once global styles come into effect the font should match the mockup better.